### PR TITLE
Prevent out of bounds accesses in decode-code-length-entries

### DIFF
--- a/deflate.lisp
+++ b/deflate.lisp
@@ -445,17 +445,29 @@ lengths for further processing."
            (setf (aref result index) code)
            (incf index))
         (16
+           (when (= index 0)
+             (error 'deflate-decompression-error
+                    :format-control "Length entries start with a repetition!"))
            (let ((length (+ 3 (bit-stream-read-bits bit-stream 2))))
+             (unless (<= (+ index length) count)
+               (error 'deflate-decompression-error
+                      :format-control "Length entries expand out of bounds."))
              (dotimes (i length)
                (setf (aref result (+ index i)) (aref result (1- index))))
              (incf index length)))
         (17
            (let ((length (+ 3 (bit-stream-read-bits bit-stream 3))))
+             (unless (<= (+ index length) count)
+               (error 'deflate-decompression-error
+                      :format-control "Length entries expand out of bounds."))
              (dotimes (i length)
                (setf (aref result (+ index i)) 0))
              (incf index length)))
         (18
            (let ((length (+ 11 (bit-stream-read-bits bit-stream 7))))
+             (unless (<= (+ index length) count)
+               (error 'deflate-decompression-error
+                      :format-control "Length entries expand out of bounds."))
              (dotimes (i length)
                (setf (aref result (+ index i)) 0))
              (incf index length)))))))


### PR DESCRIPTION
While `decode-code-length-entries` checks that single codes don't overflow the buffer, it doesn't do so for expansions. Furthermore, starting with a repetition code will try to access the (-1)-th element.
Example zlib inputs that trigger this:
`#(120 218 237 253 181 181 109 219 182 109 219 250 111 117 140 158 196 232 136 0 0 0 0)`
`#(120 218 237 253 181 181 109 219 182 109 219 130 255 62 199 232 73 140 134 8 0 0 0 0)`