### PR TITLE
Enhance deflate test portability to ECL/ABCL

### DIFF
--- a/deflate-test.lisp
+++ b/deflate-test.lisp
@@ -37,6 +37,8 @@
    #-(or sbcl allegro cmu clisp openmcl lispworks ecl clasp abcl mocl genera mezzano) ...
    #:fundamental-binary-input-stream #:fundamental-binary-output-stream
    #:stream-read-byte #:stream-write-byte)
+  #+ecl
+  (:shadowing-import-from :gray #:stream-element-type)
   (:export
    #:perform-all-tests
    #:perform-deflate-tests

--- a/deflate.asd
+++ b/deflate.asd
@@ -40,6 +40,6 @@
   :in-order-to ((test-op (test-op "deflate/test"))))
 
 (defsystem "deflate/test"
-  :depends-on ("deflate")
+  :depends-on ("deflate" #+abcl (:require :gray-streams))
   :components ((:file "deflate-test"))
   :perform (test-op (o c) (symbol-call '#:deflate-test '#:perform-all-tests)))


### PR DESCRIPTION
Fixes #5 by adding special handling for ECL/ABCL gray-streams idiosyncracies. 